### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,9 @@
 name: Deploy to Cloudflare Pages
 
+permissions:
+  contents: read
+  pages: write
+
 on:
   # push:
   #   branches:


### PR DESCRIPTION
Potential fix for [https://github.com/kjanat/chatlogger-dashboard/security/code-scanning/4](https://github.com/kjanat/chatlogger-dashboard/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Based on the steps in the workflow, the following permissions are needed:
- `contents: read` to allow the workflow to read repository contents (e.g., during the `actions/checkout` step).
- `pages: write` to allow the workflow to deploy to Cloudflare Pages.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
